### PR TITLE
fix: move @types/node to dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
         "@semantic-release/changelog": "5.0.1",
         "@semantic-release/git": "9.0.0",
         "@types/jest": "26.0.19",
+        "@types/node": "14.14.36",
         "conventional-changelog-conventionalcommits": "4.5.0",
         "jest": "26.6.3",
         "jest-junit": "12.0.0",
@@ -47,7 +48,6 @@
         "typescript": "4.1.3"
     },
     "dependencies": {
-        "@types/node": ">=10.0.0",
         "tslib": "^2.0.0"
     },
     "scripts": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1049,10 +1049,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:*, @types/node@npm:>= 8, @types/node@npm:>=10.0.0":
+"@types/node@npm:*, @types/node@npm:>= 8":
   version: 14.0.23
   resolution: "@types/node@npm:14.0.23"
   checksum: 35415a294f536c2b14d29ec02a733af23405f4e7e87dace5b4392a69358aae7a14d28805a528b6e9a5f55cfbd9e035bd817e4db0325945fe0332db40ecabdf84
+  languageName: node
+  linkType: hard
+
+"@types/node@npm:14.14.36":
+  version: 14.14.36
+  resolution: "@types/node@npm:14.14.36"
+  checksum: 9eff5863af3ddf3dfd0964ce7da85e663df2c05d091412b8c97d069e61b00760fa4ce788442733bdf07ad69ce408088c0bef2fa81b5cfdca54d31117618385f3
   languageName: node
   linkType: hard
 
@@ -5855,7 +5862,7 @@ fsevents@~2.3.1:
     "@semantic-release/changelog": 5.0.1
     "@semantic-release/git": 9.0.0
     "@types/jest": 26.0.19
-    "@types/node": ">=10.0.0"
+    "@types/node": 14.14.36
     conventional-changelog-conventionalcommits: 4.5.0
     jest: 26.6.3
     jest-junit: 12.0.0


### PR DESCRIPTION
`mdb-reader` doesn't use any node libray.