### PR TITLE
fix: round milliseconds in datetime parser

### DIFF
--- a/src/data/datetime.spec.ts
+++ b/src/data/datetime.spec.ts
@@ -1,0 +1,13 @@
+import { readDateTime } from "./datetime";
+
+it("without milliseconds", () => {
+    const buffer = Buffer.alloc(8);
+    buffer.writeDoubleLE(32234.51375);
+    expect(readDateTime(buffer)).toMatchInlineSnapshot(`1988-04-01T12:19:48.000Z`);
+});
+
+it("with milliseconds", () => {
+    const buffer = Buffer.alloc(8);
+    buffer.writeDoubleLE(32234.513755787);
+    expect(readDateTime(buffer)).toMatchInlineSnapshot(`1988-04-01T12:19:48.500Z`);
+});

--- a/src/data/datetime.ts
+++ b/src/data/datetime.ts
@@ -1,5 +1,5 @@
 export function readDateTime(buffer: Buffer): Date {
     const td = buffer.readDoubleLE();
     const daysDiff = 25569; // days between 1899-12-30 and 01-01-19070
-    return new Date((td - daysDiff) * 86400 * 1000);
+    return new Date(Math.round((td - daysDiff) * 86400 * 1000));
 }


### PR DESCRIPTION
Fixes #122 