### PR TITLE
fix: use default import for fast-xml-parser

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -9,7 +9,7 @@ jobs:
         runs-on: ubuntu-20.04
         strategy:
             matrix:
-                node: ["14", "16"]
+                node: ["14.0.0", "14", "16.0.0", "16"]
 
         steps:
             - uses: actions/checkout@v2

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -28,8 +28,10 @@ jobs:
               run: npm run lint
             - name: Build
               run: npm run build
-            - name: Test
+            - name: Test (Unit)
               run: npm test -- --ci --runInBand --coverage
+            - name: Test (Imports)
+              run: node --input-type=module -e "import MDBReader from './lib/index.js';"
 
             - name: Install dependencies (examples/browser)
               run: npm ci

--- a/src/codec-handler/handlers/office/agile/EncryptionDescriptor.ts
+++ b/src/codec-handler/handlers/office/agile/EncryptionDescriptor.ts
@@ -1,7 +1,7 @@
-import { XMLParser } from "fast-xml-parser";
+import FastXMLParser from "fast-xml-parser";
 import { EncryptionDescriptor } from "./types";
 
-const xmlParser = new XMLParser({
+const xmlParser = new FastXMLParser.XMLParser({
     ignoreAttributes: false,
     attributeNamePrefix: "",
     parseAttributeValue: true,


### PR DESCRIPTION
Named import of `fast-xml-parser` fails for node versions prior [14.13](https://nodejs.org/uk/blog/release/v14.13.0/)

The fix is to use the default import instead of named import.


## Node versions

| Node Version   | Works? |
| -------------- | ------ |
| 14.14 (latest) | Yes    |
| 16.0           | Yes    |
| 14.18 (latest) | Yes    |
| 14.13          | Yes    |
| 14.12          | No     |

## Error messages
### 14.12
```
import { XMLParser } from "fast-xml-parser";
         ^^^^^^^^^
SyntaxError: The requested module 'fast-xml-parser' is expected to be of type CommonJS, which does not support named exports. CommonJS modules can be imported by importing the default export.
For example:
import pkg from 'fast-xml-parser';
const { XMLParser } = pkg;
```

### 14.0
```
import { XMLParser } from "fast-xml-parser";
         ^^^^^^^^^
SyntaxError: The requested module 'fast-xml-parser' does not provide an export named 'XMLParser'
```

## Tickets

fixes #168
