### PR TITLE
fix: handle non-ascii characters in Jet3 databases

### DIFF
--- a/src/JetFormat/Jet3Format.ts
+++ b/src/JetFormat/Jet3Format.ts
@@ -6,7 +6,7 @@ export const jet3Format: JetFormat = {
 
     pageSize: 2048,
 
-    textEncoding: "utf8",
+    textEncoding: "unknown",
 
     defaultSortOrder: GENERAL_97_SORT_ORDER,
 

--- a/src/JetFormat/types.ts
+++ b/src/JetFormat/types.ts
@@ -5,7 +5,7 @@ export interface JetFormat {
 
     pageSize: number;
 
-    textEncoding: "utf8" | "ucs-2";
+    textEncoding: "unknown" | "ucs-2";
 
     defaultSortOrder: Readonly<SortOrder>;
 

--- a/src/unicodeCompression.spec.ts
+++ b/src/unicodeCompression.spec.ts
@@ -4,10 +4,10 @@ const compressionHeader = Buffer.from([0xff, 0xfe]);
 
 describe("uncompressText", () => {
     it("decodes Jet3 buffer", () => {
-        const inputString = "This is a test";
-        const inputBuffer = Buffer.from(inputString, "utf8");
+        const inputString = "Série";
+        const inputBuffer = Buffer.from([0x53, 0xe9, 0x72, 0x69, 0x65]);
 
-        const result = uncompressText(inputBuffer, { textEncoding: "utf8" });
+        const result = uncompressText(inputBuffer, { textEncoding: "unknown" });
         expect(result).toBe(inputString);
     });
 

--- a/src/unicodeCompression.ts
+++ b/src/unicodeCompression.ts
@@ -62,9 +62,9 @@ function decodeWindows1252(buffer: Buffer): string {
     const result = Buffer.alloc(buffer.length * 2);
 
     for (let i = 0; i < buffer.length; ++i) {
-        const idx1 = buffer[i] * 2;
-        result[i * 2] = charsBuffer[idx1];
-        result[i * 2 + 1] = charsBuffer[idx1 + 1];
+        const index = buffer[i] * 2;
+        result[i * 2] = charsBuffer[index];
+        result[i * 2 + 1] = charsBuffer[index + 1];
     }
 
     return result.toString("ucs2");

--- a/src/unicodeCompression.ts
+++ b/src/unicodeCompression.ts
@@ -3,9 +3,11 @@ import { JetFormat } from "./JetFormat";
 /**
  * @see https://github.com/brianb/mdbtools/blob/d6f5745d949f37db969d5f424e69b54f0da60b9b/HACKING#L823-L831
  */
-export function uncompressText(buffer: Buffer, format: Pick<JetFormat, 'textEncoding'>): string {
-    if (format.textEncoding === "utf8") {
-        return buffer.toString("utf8");
+export function uncompressText(buffer: Buffer, format: Pick<JetFormat, "textEncoding">): string {
+    if (format.textEncoding === "unknown") {
+        // We assume windows 1252 (windows default) is used
+        // In some cases this might not work
+        return decodeWindows1252(buffer);
     }
 
     if (buffer.length <= 2 || (buffer.readUInt8(0) & 0xff) !== 0xff || (buffer.readUInt8(1) & 0xff) !== 0xfe) {
@@ -32,4 +34,38 @@ export function uncompressText(buffer: Buffer, format: Pick<JetFormat, 'textEnco
     }
 
     return uncompressedBuffer.slice(0, uncompressedBufferPos).toString("ucs-2");
+}
+
+/**
+ * @see https://github.com/ashtuchkin/iconv-lite/blob/928f7c68e1be51c1391c70dbee244fd32623f121/encodings/sbcs-codec.js#L17-L19
+ */
+const ASCII_CHARS = Array.from(new Array(128).keys())
+    .map((i) => String.fromCharCode(i))
+    .join("");
+/**
+ * @see https://github.com/ashtuchkin/iconv-lite/blob/5d99a923f2bb9352abf80f8aeb850d924a8a1e38/encodings/sbcs-data-generated.js#L82
+ */
+const WINDOWS_1252_CHARS =
+    "€�‚ƒ„…†‡ˆ‰Š‹Œ�Ž��‘’“”•–—˜™š›œ�žŸ ¡¢£¤¥¦§¨©ª«¬­®¯°±²³´µ¶·¸¹º»¼½¾¿ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖ×ØÙÚÛÜÝÞßàáâãäåæçèéêëìíîïðñòóôõö÷øùúûüýþÿ";
+
+/**
+ * Decodes CP1252 / windows 1252
+ *
+ * Copied in to not add a dependency and keep the bundle (browser) small
+ *
+ * @see https://github.com/ashtuchkin/iconv-lite/blob/928f7c68e1be51c1391c70dbee244fd32623f121/encodings/sbcs-codec.js#L58-L69
+ */
+function decodeWindows1252(buffer: Buffer): string {
+    const chars = `${ASCII_CHARS}${WINDOWS_1252_CHARS}`;
+    const charsBuffer = Buffer.from(chars, "ucs2");
+
+    const result = Buffer.alloc(buffer.length * 2);
+
+    for (let i = 0; i < buffer.length; ++i) {
+        const idx1 = buffer[i] * 2;
+        result[i * 2] = charsBuffer[idx1];
+        result[i * 2 + 1] = charsBuffer[idx1 + 1];
+    }
+
+    return result.toString("ucs2");
 }

--- a/src/unicodeCompression.ts
+++ b/src/unicodeCompression.ts
@@ -5,7 +5,7 @@ import { JetFormat } from "./JetFormat";
  */
 export function uncompressText(buffer: Buffer, format: Pick<JetFormat, "textEncoding">): string {
     if (format.textEncoding === "unknown") {
-        // We assume windows 1252 (windows default) is used
+        // Assume charset is windows 1252 / CP1252 (windows default)
         // In some cases this might not work
         return decodeWindows1252(buffer);
     }


### PR DESCRIPTION
When decoding Text or Memo columns of Jet3 databases the buffer was decoded as utf8 even though it was actually (probably) decoded as windows 1252. This causes issues when decoding non-ascii characters.

I copied the decoding algorithm from [`iconv-lite`](https://www.npmjs.com/package/iconv-lite) to avoid an additional dependency with loads of unused code (different encodings).

close #172
