### PR TITLE
fix: correctly read num of var cols for Jet3 dbs

### DIFF
--- a/src/JetFormat/Jet3Format.ts
+++ b/src/JetFormat/Jet3Format.ts
@@ -35,7 +35,7 @@ export const jet3Format: JetFormat = {
         rowCountOffset: 12,
 
         columnCountOffset: 25,
-        variableColumnCountOffset: 25,
+        variableColumnCountOffset: 23,
 
         logicalIndexCountOffset: 27,
         realIndexCountOffset: 31,


### PR DESCRIPTION
Wrongly copied/adjusted from mdbtools. The number of variable columns in a table was read from the wrong location in the buffer.

This could lead to various different issues when reading data from Jet3 databases. All newer databases were not affected as they use a different format.

This probably didn't cause any issues earlier as the accidentally referenced bytes were zeros.