### PR TITLE
fix: do not use `Buffer` on import

### DIFF
--- a/development.md
+++ b/development.md
@@ -1,0 +1,3 @@
+# Notes for development of `mdb-reader`
+
+-   Do not use the global `Buffer` outside of functions. This may cause issues in browsers if the Buffer-polyfill wasn't imported yet.

--- a/src/Database.ts
+++ b/src/Database.ts
@@ -144,10 +144,10 @@ export default class Database {
 }
 
 const ENCRYPTION_START = 0x18;
-const ENCRYPTION_KEY = Buffer.from([0xc7, 0xda, 0x39, 0x6b]);
+const ENCRYPTION_KEY = [0xc7, 0xda, 0x39, 0x6b];
 function decryptHeader(buffer: Buffer, format: JetFormat): void {
     const decryptedBuffer = decryptRC4(
-        ENCRYPTION_KEY,
+        Buffer.from(ENCRYPTION_KEY),
         buffer.slice(ENCRYPTION_START, ENCRYPTION_START + format.databaseDefinitionPage.encryptedSize)
     );
     decryptedBuffer.copy(buffer, ENCRYPTION_START);

--- a/src/JetFormat/index.ts
+++ b/src/JetFormat/index.ts
@@ -12,7 +12,7 @@ export type { JetFormat } from "./types.js";
 
 const OFFSET_VERSION = 0x14;
 const OFFSET_ENGINE_NAME = 0x4;
-const MSISAM_ENGINE = Buffer.from("MSISAM Database", "ascii");
+const MSISAM_ENGINE = "MSISAM Database";
 
 /**
  * Returns the database format of the given buffer
@@ -30,7 +30,10 @@ export function getJetFormat(buffer: Buffer): JetFormat {
         case 0x00: // JET 3
             return jet3Format;
         case 0x01: // JET 4
-            if (buffer.slice(OFFSET_ENGINE_NAME, OFFSET_ENGINE_NAME + MSISAM_ENGINE.length).equals(MSISAM_ENGINE)) {
+            if (
+                buffer.slice(OFFSET_ENGINE_NAME, OFFSET_ENGINE_NAME + MSISAM_ENGINE.length).toString("ascii") ===
+                MSISAM_ENGINE
+            ) {
                 return msisamFormat;
             }
 

--- a/src/codec-handler/handlers/office/agile/index.ts
+++ b/src/codec-handler/handlers/office/agile/index.ts
@@ -6,9 +6,9 @@ import { getPageEncodingKey } from "../../../util.js";
 import { parseEncryptionDescriptor } from "./EncryptionDescriptor.js";
 import { PasswordKeyEncryptor } from "./types.js";
 
-const ENC_VERIFIER_INPUT_BLOCK = Buffer.from([0xfe, 0xa7, 0xd2, 0x76, 0x3b, 0x4b, 0x9e, 0x79]);
-const ENC_VERIFIER_VALUE_BLOCK = Buffer.from([0xd7, 0xaa, 0x0f, 0x6d, 0x30, 0x61, 0x34, 0x4e]);
-const ENC_VALUE_BLOCK = Buffer.from([0x14, 0x6e, 0x0b, 0xe7, 0xab, 0xac, 0xd0, 0xd6]);
+const ENC_VERIFIER_INPUT_BLOCK = [0xfe, 0xa7, 0xd2, 0x76, 0x3b, 0x4b, 0x9e, 0x79];
+const ENC_VERIFIER_VALUE_BLOCK = [0xd7, 0xaa, 0x0f, 0x6d, 0x30, 0x61, 0x34, 0x4e];
+const ENC_VALUE_BLOCK = [0x14, 0x6e, 0x0b, 0xe7, 0xab, 0xac, 0xd0, 0xd6];
 
 export function createAgileCodecHandler(encodingKey: Buffer, encryptionProvider: Buffer, password: Buffer): CodecHandler {
     const { keyData, passwordKeyEncryptor } = parseEncryptionDescriptor(encryptionProvider);
@@ -45,7 +45,7 @@ export function createAgileCodecHandler(encodingKey: Buffer, encryptionProvider:
 function decryptKeyValue(password: Buffer, passwordKeyEncryptor: PasswordKeyEncryptor): Buffer {
     const key = deriveKey(
         password,
-        ENC_VALUE_BLOCK,
+        Buffer.from(ENC_VALUE_BLOCK),
         passwordKeyEncryptor.hash.algorithm,
         passwordKeyEncryptor.salt,
         passwordKeyEncryptor.spinCount,
@@ -63,7 +63,7 @@ function decryptKeyValue(password: Buffer, passwordKeyEncryptor: PasswordKeyEncr
 function decryptVerifierHashInput(password: Buffer, passwordKeyEncryptor: PasswordKeyEncryptor): Buffer {
     const key = deriveKey(
         password,
-        ENC_VERIFIER_INPUT_BLOCK,
+        Buffer.from(ENC_VERIFIER_INPUT_BLOCK),
         passwordKeyEncryptor.hash.algorithm,
         passwordKeyEncryptor.salt,
         passwordKeyEncryptor.spinCount,
@@ -81,7 +81,7 @@ function decryptVerifierHashInput(password: Buffer, passwordKeyEncryptor: Passwo
 function decryptVerifierHashValue(password: Buffer, passwordKeyEncryptor: PasswordKeyEncryptor): Buffer {
     const key = deriveKey(
         password,
-        ENC_VERIFIER_VALUE_BLOCK,
+        Buffer.from(ENC_VERIFIER_VALUE_BLOCK),
         passwordKeyEncryptor.hash.algorithm,
         passwordKeyEncryptor.salt,
         passwordKeyEncryptor.spinCount,


### PR DESCRIPTION
This may cause issues in browsers if the Buffer-polyfill wasn't imported yet.
