### PR TITLE
Use `exports` field in the `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,9 +2,11 @@
     "name": "mdb-reader",
     "version": "2.2.6",
     "description": "JavaScript library to read data from Access databases",
-    "main": "lib/node/index.js",
-    "browser": "lib/browser/index.js",
-    "types": "lib/types/index.d.ts",
+    "exports": {
+        "types": "./lib/types/index.d.ts",
+        "node": "./lib/node/index.js",
+        "default": "./lib/browser/index.js"
+    },
     "sideEffects": false,
     "type": "module",
     "files": [


### PR DESCRIPTION
Node documentation for [package entry points](https://nodejs.org/api/packages.html#package-entry-points) recommends using `exports` over `main`.

After upgrading an existing working project to Vite v5, it was attempting to use `lib/node` to build for the browser and failing, which is fixed by this change (there are still some warnings but I believe that is a separate issue).

This might even help with Issue #290 though I'm not familiar with Web Dev Server.

I think with [conditional exports](https://nodejs.org/api/packages.html#conditional-exports), it might be better to simplify the lib output and build step with something like this:

```json
"exports": {
    ".": "./lib/index.js",
    "./lib/environment.js": {
        "node": "./lib/environment/node.js",
        "default": "./lib/environment/browser.js"
    }
}
```

However, I haven't tried and I suspect that it would be a breaking change for some users.