### PR TITLE
fix: do not skip last char when decompressing text where the last chars are uncompressed

### DIFF
--- a/src/unicodeCompression.spec.ts
+++ b/src/unicodeCompression.spec.ts
@@ -20,37 +20,49 @@ describe("uncompressText", () => {
         expect(result).to.eq(inputString);
     });
 
-    it("decodes compressed ascii without uncompressed characters", () => {
-        const inputString = "This is a test";
-        const inputBuffer = Buffer.from(inputString, "ucs-2");
-        const compressedInputBuffer = inputBuffer.filter((_byte, index) => index % 2 === 0);
-        expect(compressedInputBuffer.length).to.eq(inputBuffer.length / 2);
+    describe("decodes compressed ascii", () => {
+        it("without uncompressed characters", () => {
+            const inputString = "This is a test";
+            const inputBuffer = Buffer.from(inputString, "ucs-2");
+            const compressedInputBuffer = inputBuffer.filter((_byte, index) => index % 2 === 0);
+            expect(compressedInputBuffer.length).to.eq(inputBuffer.length / 2);
 
-        const fullInputBuffer = Buffer.concat([compressionHeader, compressedInputBuffer]);
+            const fullInputBuffer = Buffer.concat([compressionHeader, compressedInputBuffer]);
 
-        const result = uncompressText(fullInputBuffer, { textEncoding: "ucs-2" });
-        expect(result).to.eq(inputString);
-    });
+            const result = uncompressText(fullInputBuffer, { textEncoding: "ucs-2" });
+            expect(result).to.eq(inputString);
+        });
 
-    it("decodes compressed ascii with uncompressed characters", () => {
-        const asciiInputString = "ASCII";
-        const asciiInputBuffer = Buffer.from(asciiInputString, "ucs-2");
-        const asciiCompressedInputBuffer = asciiInputBuffer.filter((_byte, index) => index % 2 === 0);
-        expect(asciiCompressedInputBuffer.length).to.eq(asciiInputBuffer.length / 2);
+        it("with uncompressed characters", () => {
+            const asciiInputString = "ASCII";
+            const asciiInputBuffer = Buffer.from(asciiInputString, "ucs-2");
+            const asciiCompressedInputBuffer = asciiInputBuffer.filter((_byte, index) => index % 2 === 0);
+            expect(asciiCompressedInputBuffer.length).to.eq(asciiInputBuffer.length / 2);
 
-        const unicodeInputString = "Ț✚";
-        const unicodeInputBuffer = Buffer.from(unicodeInputString, "ucs-2");
+            const unicodeInputString = "Ț✚";
+            const unicodeInputBuffer = Buffer.from(unicodeInputString, "ucs-2");
 
-        const fullInputBuffer = Buffer.concat([
-            compressionHeader,
-            asciiCompressedInputBuffer,
-            Buffer.from([0x00]),
-            unicodeInputBuffer,
-            Buffer.from([0x00]),
-            asciiCompressedInputBuffer,
-        ]);
+            const fullInputBuffer = Buffer.concat([
+                compressionHeader,
+                asciiCompressedInputBuffer,
+                Buffer.from([0x00]),
+                unicodeInputBuffer,
+                Buffer.from([0x00]),
+                asciiCompressedInputBuffer,
+            ]);
 
-        const result = uncompressText(fullInputBuffer, { textEncoding: "ucs-2" });
-        expect(result).to.eq(`${asciiInputString}${unicodeInputString}${asciiInputString}`);
+            const result = uncompressText(fullInputBuffer, { textEncoding: "ucs-2" });
+            expect(result).to.eq(`${asciiInputString}${unicodeInputString}${asciiInputString}`);
+        });
+
+        it("with an uncompressed character as last char", () => {
+            const fullInputBuffer = Buffer.concat([
+                compressionHeader,
+                Buffer.from([0x00]),
+                Buffer.from("Hello world", "ucs-2"),
+            ]);
+            const result = uncompressText(fullInputBuffer, { textEncoding: "ucs-2" });
+            expect(result).to.eq("Hello world");
+        });
     });
 });

--- a/src/unicodeCompression.ts
+++ b/src/unicodeCompression.ts
@@ -22,15 +22,17 @@ export function uncompressText(buffer: Buffer, format: Pick<JetFormat, "textEnco
     const uncompressedBuffer = Buffer.alloc((buffer.length - curPos) * 2);
     let uncompressedBufferPos = 0;
     while (curPos < buffer.length) {
-        const curByte = buffer.readUInt8(curPos++);
-        if (curByte === 0) {
+        if (buffer.readUInt8(curPos) === 0) {
             compressedMode = !compressedMode;
+            curPos++;
         } else if (compressedMode) {
-            uncompressedBuffer[uncompressedBufferPos++] = curByte;
+            uncompressedBuffer[uncompressedBufferPos++] = buffer.readUInt8(curPos++);
             uncompressedBuffer[uncompressedBufferPos++] = 0;
         } else if (buffer.length - curPos >= 2) {
-            uncompressedBuffer[uncompressedBufferPos++] = curByte;
             uncompressedBuffer[uncompressedBufferPos++] = buffer.readUInt8(curPos++);
+            uncompressedBuffer[uncompressedBufferPos++] = buffer.readUInt8(curPos++);
+        } else {
+            break;
         }
     }
 


### PR DESCRIPTION
Compressed text is not 100% compressed. It's a mix of compressed and uncompressed text. The compression mode switches between parsing compressed and uncompressed bytes using a 0x00 byte.

There was a bug where the last character was accidentally skipped when it was uncompressed. The root cause was that the number of remaining characters was not calculated correctly and it was assumed that the one char shorter than it actually was. 

With this PR, the decompress code should be easier to read and it is more obvious when the `curPos` variable is incremented. The performance is slightly worse as we read some bytes twice. But I think we can ignore that aspect here.